### PR TITLE
better compatibility with unpatched pysmt

### DIFF
--- a/wmibench/io.py
+++ b/wmibench/io.py
@@ -148,7 +148,7 @@ def smt_to_nested(expression):
         return convert_children("+")
     if expression.is_minus():
         return convert_children("-")
-    if expression.is_exp():
+    if hasattr(expression, "is_exp") and expression.is_exp():
         return convert_children("exp")
     if expression.is_ite():
         return convert_children("ite")


### PR DESCRIPTION
The vanilla pysmt doesn't have the `is_exp` function, but we do not necessarily need it. This pull request guards the method call behind an `hasattr`-check, which check whether the function is defined or not. We can now generate benchmarks without the exponential function using the library.